### PR TITLE
fix broken package by specifying correct outdir and package entrypoint

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,5 +39,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn install --frozen-lockfile
-          yarn prepublish
+          yarn build
           yarn release

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:watch": "jest --watch --config ./jest.config.js --runInBand",
     "test:cover": "jest --config ./jest.config.js --coverage && cat ./coverage/lcov.info | node_modules/.bin/coveralls",
     "format": "prettier --write \"src/**/*.+(ts|tsx|js|css|scss|json)\"",
-    "build-storybook": "build-storybook -o ./.storybook/static"
+    "clean": "rimraf swish-ui/package-lock.json && rimraf swish-ui/lib && rimraf swish-ui/node_modules && rimraf .storybook/static",
+    "build-storybook": "npm run clean && build-storybook -o ./.storybook/static"
   },
   "husky": {
     "hooks": {

--- a/swish-ui/.tsconfig.release.json
+++ b/swish-ui/.tsconfig.release.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "./dist/",
-    "module": "commonjs",
-    "target": "es5",
+    "outDir": "lib",
+    "target": "es2015",
     "allowJs": true,
     "sourceMap": true,
     "jsx": "react",
@@ -16,6 +15,6 @@
     "allowSyntheticDefaultImports": true
   },
   "compileOnSave": true,
-  "include": ["components/**/*"],
+  "include": ["components"],
   "exclude": ["node_modules"]
 }

--- a/swish-ui/package.json
+++ b/swish-ui/package.json
@@ -1,12 +1,14 @@
 {
-  "name": "@swish-design/core",
-  "version": "0.1.1",
+  "name": "swish-design",
+  "title": "Swish Design",
   "description": "An enterprise-ready and accessible UI design library of React components",
-  "main": "dist/index.ts",
-  "author": "Swish Design Team",
+  "version": "0.1.1",
   "license": "MIT",
+  "main": "lib",
+  "types": "lib",
+  "author": "Swish Design Team",
   "files": [
-    "dist"
+    "lib"
   ],
   "repository": {
     "type": "git",
@@ -16,7 +18,7 @@
     "url": "https://github.com/krfong916/swish-design/issues"
   },
   "scripts": {
-    "prepublish": "rimraf dist && webpack --color --mode=production",
+    "build": "rimraf dist && webpack --color --mode=production",
     "release": "auto shipit --base-branch=main"
   },
   "devDependencies": {
@@ -60,5 +62,9 @@
     "classnames": "^2.2.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
+  },
+  "peerDependencies": {
+    "classnames": ">=2.2.6",
+    "react": ">=16.0.0"
   }
 }

--- a/swish-ui/webpack.config.js
+++ b/swish-ui/webpack.config.js
@@ -1,10 +1,9 @@
 const path = require("path");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const webpack = require("webpack");
 
 module.exports = {
   entry: "./index.ts",
-  devtool: "inline-source-map",
+  devtool: "source-map",
   module: {
     rules: [
       {
@@ -25,7 +24,7 @@ module.exports = {
         test: /\.s[ac]ss$/i,
         include: /components/,
         exclude: /node_modules/,
-        use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
+        use: ["style-loader", "css-loader", "sass-loader"],
       },
     ],
   },
@@ -33,10 +32,9 @@ module.exports = {
     extensions: [".tsx", ".ts", ".js"],
   },
   output: {
-    filename: "swish-design.js",
-    path: path.resolve(__dirname, "dist"),
+    filename: "index.js",
+    path: path.resolve(__dirname, "lib"),
     libraryTarget: "commonjs2",
-    library: "swishDesign",
   },
-  plugins: [new MiniCssExtractPlugin(), new webpack.ProgressPlugin()],
+  plugins: [new webpack.ProgressPlugin()],
 };


### PR DESCRIPTION
- The issue was building that I built a commonJS module. We want to export an es2015 module.
- We require users to have react >= v16 installed when using our component. We specify our requirement in peerDependency's
- Third, we add a style-loader when we transpile and bundle our component and styles together.